### PR TITLE
Make StackTemplate immutable.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = "0.0.2-SNAPSHOT"
+version = "0.0.3-SNAPSHOT"
 group = "cloud.rio"
 
 val awsSdkVersion = "1.11.481"

--- a/src/test/kotlin/cloud/rio/amazonas/StackTemplateTest.kt
+++ b/src/test/kotlin/cloud/rio/amazonas/StackTemplateTest.kt
@@ -111,4 +111,22 @@ class StackTemplateTest {
         assertTrue(listOf("test_server_arn_new", "5678").contains(stack.tags[1].value))
     }
 
+    @Test
+    fun `should have immutable tags`() {
+        val stack = StackTemplate(stackName, configFilePath)
+
+        stack.withTag("ServerCertificateArn", "test_server_arn_new")
+
+        assertEquals(0, stack.tags.size)
+    }
+
+    @Test
+    fun `should have immutable parameters`() {
+        val stack = StackTemplate(stackName, configFilePath)
+
+        stack.withParameter("ServerCertificateArn", "test_server_arn_new")
+
+        assertEquals(0, stack.parameters.size)
+    }
+
 }


### PR DESCRIPTION
So far, the state of a StackTemplate after applying one of the "withers" was not defined by the unit tests. In fact it was altered, which might be rather unexpected. With this commit we define it to be unaltered and change the implementation accordingly.

The version is updated to 0.0.3-SNAPSHOT.