### PR TITLE
Add CertificateClient for issuing ACM certificates.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = "0.0.3-SNAPSHOT"
+version = "0.0.4-SNAPSHOT"
 group = "cloud.rio"
 
 val awsSdkVersion = "1.11.481"
@@ -28,7 +28,8 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-cloudformation:$awsSdkVersion")
     implementation("com.amazonaws:aws-java-sdk-sts:$awsSdkVersion")
     implementation("com.amazonaws:aws-java-sdk-s3:$awsSdkVersion")
-
+    implementation("com.amazonaws:aws-java-sdk-acm:$awsSdkVersion")
+    implementation("com.amazonaws:aws-java-sdk-route53:$awsSdkVersion")
     testCompile("org.junit.jupiter:junit-jupiter-api:$junit5Version")
     testCompile("org.junit.jupiter:junit-jupiter-params:$junit5Version")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junit5Version")

--- a/src/main/kotlin/cloud/rio/amazonas/CertificateClient.kt
+++ b/src/main/kotlin/cloud/rio/amazonas/CertificateClient.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 TB Digital Services GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This class is a derivative work of the
+ * jp.classmethod.aws.gradle.cloudformation package. It has been migrated
+ * to Kotlin, the two classes AmazonCloudFormationMigrateStackTask and
+ * AmazonCloudFormationWaitStackStatusTask have been merged into one,
+ * and over time several refactorings were performed.
+ *
+ * The original work was published with the following copyright notice:
+ *
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cloud.rio.amazonas
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.certificatemanager.AWSCertificateManager
+import com.amazonaws.services.certificatemanager.AWSCertificateManagerClientBuilder
+import com.amazonaws.services.certificatemanager.model.*
+import com.amazonaws.services.route53.AmazonRoute53
+import com.amazonaws.services.route53.AmazonRoute53ClientBuilder
+import com.amazonaws.services.route53.model.*
+import com.amazonaws.services.route53.model.ResourceRecord
+
+class CertificateClient(
+        private val acmClient: AWSCertificateManager,
+        private val route53Client: AmazonRoute53,
+        private val validationCheckIntervalMillis: Long = 10000,
+        private val validationDNSEntryTTL: Long = 300
+) {
+
+    constructor(credentialsProvider: AWSCredentialsProvider, region: String) :
+            this(
+                    AWSCertificateManagerClientBuilder.standard()
+                            .withRegion(region)
+                            .withCredentials(credentialsProvider)
+                            .build(),
+                    AmazonRoute53ClientBuilder.standard()
+                            .withRegion(region)
+                            .withCredentials(credentialsProvider)
+                            .build()
+            )
+
+    fun retrieveOrRequestCertificate(hostedZoneName: String, domainName: String): String =
+            retrieveExistingCertificate(domainName) ?: requestAndValidateNewCertificate(domainName, hostedZoneName)
+
+    private fun retrieveExistingCertificate(domainName: String): String? {
+        var listCertificatesResult: ListCertificatesResult? = null
+        do {
+            listCertificatesResult = acmClient.listCertificates(ListCertificatesRequest().withNextToken(listCertificatesResult?.nextToken))
+            val existingCertificate = listCertificatesResult.certificateSummaryList
+                    .firstOrNull { it -> it.domainName == (domainName) }
+            if (existingCertificate != null) return existingCertificate.certificateArn
+        } while (listCertificatesResult?.nextToken != null)
+        return null
+    }
+
+    private fun requestAndValidateNewCertificate(domainName: String, hostedZoneName: String): String {
+        val newCertificate = acmClient.requestCertificate(
+                RequestCertificateRequest()
+                        .withDomainName(domainName)
+                        .withValidationMethod(ValidationMethod.DNS)
+        )
+
+        var validation: DomainValidation
+        do {
+            val describeCertificate = acmClient.describeCertificate(
+                    DescribeCertificateRequest()
+                            .withCertificateArn(newCertificate.certificateArn)
+            )
+            validation = describeCertificate.certificate.domainValidationOptions.first()
+        } while (validation.validationStatus != "PENDING_VALIDATION")
+
+        val resourceRecord = validation.resourceRecord
+        val resourceRecordSet = ResourceRecordSet()
+                .withName(resourceRecord.name)
+                .withType(resourceRecord.type)
+                .withTTL(validationDNSEntryTTL)
+                .withResourceRecords(
+                        ResourceRecord().withValue(resourceRecord.value)
+                )
+        val hostedZoneId = getHostedZoneId(hostedZoneName)
+        route53Client.changeResourceRecordSets(
+                ChangeResourceRecordSetsRequest()
+                        .withHostedZoneId(hostedZoneId)
+                        .withChangeBatch(
+                                ChangeBatch().withChanges(
+                                        Change().withAction("UPSERT")
+                                                .withResourceRecordSet(resourceRecordSet)
+                                )
+                        )
+        )
+        do {
+            val describeCertificate = acmClient.describeCertificate(
+                    DescribeCertificateRequest()
+                            .withCertificateArn(newCertificate.certificateArn)
+            )
+            validation = describeCertificate.certificate.domainValidationOptions.first()
+            println("Waiting for certificate to be validated. Current status: ${validation.validationStatus}")
+            Thread.sleep(validationCheckIntervalMillis)
+        } while (validation.validationStatus != "SUCCESS")
+
+        return newCertificate.certificateArn
+    }
+
+    private fun getHostedZoneId(hostedZoneName: String): String? {
+        var listHostedZonesResult: ListHostedZonesResult? = null
+        do {
+            listHostedZonesResult = route53Client.listHostedZones(ListHostedZonesRequest().withMarker(listHostedZonesResult?.marker))
+            val hostedZone = listHostedZonesResult.hostedZones
+                    .firstOrNull { it -> it.name == ("$hostedZoneName.") }
+            if (hostedZone != null) return hostedZone.id
+        } while (listHostedZonesResult?.marker != null)
+        return null
+    }
+}

--- a/src/test/kotlin/cloud/rio/amazonas/CertificateClientTest.kt
+++ b/src/test/kotlin/cloud/rio/amazonas/CertificateClientTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2019 TB Digital Services GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This class is a derivative work of the
+ * jp.classmethod.aws.gradle.cloudformation package. It has been migrated
+ * to Kotlin, the two classes AmazonCloudFormationMigrateStackTask and
+ * AmazonCloudFormationWaitStackStatusTask have been merged into one,
+ * and over time several refactorings were performed.
+ *
+ * The original work was published with the following copyright notice:
+ *
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cloud.rio.amazonas
+
+import com.amazonaws.services.certificatemanager.AWSCertificateManager
+import com.amazonaws.services.certificatemanager.model.*
+import com.amazonaws.services.route53.AmazonRoute53
+import com.amazonaws.services.route53.model.ChangeResourceRecordSetsResult
+import com.amazonaws.services.route53.model.HostedZone
+import com.amazonaws.services.route53.model.ListHostedZonesResult
+import io.mockk.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("CertificateClient.retrieveOrRequestCertificate")
+internal class CertificateClientTest {
+
+    private val acmMock = mockkClass(AWSCertificateManager::class)
+    private val route53Mock = mockkClass(AmazonRoute53::class)
+
+    @BeforeEach
+    fun prepareMocks() {
+    }
+
+    @AfterEach
+    fun resetMocks() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should return the ARN of an existing certificate`() {
+        every {
+            acmMock.listCertificates(any())
+        } returns
+                ListCertificatesResult()
+                        .withCertificateSummaryList(
+                                CertificateSummary()
+                                        .withDomainName("the-domain")
+                                        .withCertificateArn("the-arn"),
+                                CertificateSummary()
+                                        .withDomainName("another-domain")
+                                        .withCertificateArn("another-arn")
+                        )
+
+        val certificateClient = CertificateClient(acmMock, route53Mock)
+        val actualArn = certificateClient.retrieveOrRequestCertificate("the-hosted-zone.", "the-domain")
+
+        assertEquals("the-arn", actualArn)
+        verify(exactly = 0) {
+            acmMock.requestCertificate(any())
+        }
+    }
+
+    @Test
+    fun `should create a new certificate and return its ARN if none exists yet`() {
+        every {
+            route53Mock.listHostedZones(any())
+        } returns
+                ListHostedZonesResult()
+                        .withHostedZones(
+                                HostedZone().withName("the-hosted-zone.").withId("hz123")
+                        )
+                        .withMarker(null)
+        val wantedDomain = "the-domain"
+        val wantedArn = "the-arn"
+        every {
+            acmMock.listCertificates(any())
+        } returns
+                ListCertificatesResult()
+                        .withCertificateSummaryList(
+                                CertificateSummary()
+                                        .withDomainName("another-domain")
+                                        .withCertificateArn("another-arn")
+                        )
+        every {
+            acmMock.requestCertificate(match { it.domainName == wantedDomain && it.validationMethod == ValidationMethod.DNS.toString() })
+        } returns
+                RequestCertificateResult().withCertificateArn(wantedArn)
+        var validated = false
+        val validationResourceRecordName = "validation-resource-record-name"
+        every {
+            acmMock.describeCertificate(match { it.certificateArn == wantedArn })
+        } answers {
+            if (!validated) {
+                DescribeCertificateResult()
+                        .withCertificate(
+                                CertificateDetail()
+                                        .withCertificateArn(wantedArn)
+                                        .withDomainName(wantedDomain)
+                                        .withDomainValidationOptions(
+                                                DomainValidation()
+                                                        .withValidationStatus("PENDING_VALIDATION")
+                                                        .withResourceRecord(
+                                                                ResourceRecord().withName(validationResourceRecordName)
+                                                        )
+                                        )
+                        )
+            } else {
+                DescribeCertificateResult()
+                        .withCertificate(
+                                CertificateDetail()
+                                        .withCertificateArn(wantedArn)
+                                        .withDomainName(wantedDomain)
+                                        .withDomainValidationOptions(
+                                                DomainValidation().withValidationStatus("SUCCESS")
+
+                                        )
+                        )
+            }
+        }
+        every {
+            route53Mock.changeResourceRecordSets(match {
+                it.hostedZoneId == "hz123"
+                        && it.changeBatch.changes.first().action == "UPSERT"
+                        && it.changeBatch.changes.first().resourceRecordSet.name == validationResourceRecordName
+            })
+        } answers {
+            validated = true
+            ChangeResourceRecordSetsResult()
+        }
+
+        val certificateClient = CertificateClient(acmMock, route53Mock, validationCheckIntervalMillis = 1)
+        val actualArn = certificateClient.retrieveOrRequestCertificate("the-hosted-zone", wantedDomain)
+
+        assertEquals(wantedArn, actualArn)
+        verify(exactly = 1) {
+            acmMock.requestCertificate(any())
+            route53Mock.changeResourceRecordSets(any())
+        }
+    }
+
+}


### PR DESCRIPTION
We add the class CertificateClient which can request an ACM certificate for a given domain in a given hosted zone and automatically validate it via Route 53 domain validation. If the corresponding certificate already exists, it will return the ARN of the existing certificate.

The class comes with unit tests and this commit increments the verison to 0.0.4-SNAPSHOT.