### PR TITLE
Correct licence for CertificateClient.

### DIFF
--- a/src/main/kotlin/cloud/rio/amazonas/CertificateClient.kt
+++ b/src/main/kotlin/cloud/rio/amazonas/CertificateClient.kt
@@ -12,28 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * This class is a derivative work of the
- * jp.classmethod.aws.gradle.cloudformation package. It has been migrated
- * to Kotlin, the two classes AmazonCloudFormationMigrateStackTask and
- * AmazonCloudFormationWaitStackStatusTask have been merged into one,
- * and over time several refactorings were performed.
- *
- * The original work was published with the following copyright notice:
- *
- * Copyright 2015-2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package cloud.rio.amazonas
 

--- a/src/test/kotlin/cloud/rio/amazonas/CertificateClientTest.kt
+++ b/src/test/kotlin/cloud/rio/amazonas/CertificateClientTest.kt
@@ -12,28 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * This class is a derivative work of the
- * jp.classmethod.aws.gradle.cloudformation package. It has been migrated
- * to Kotlin, the two classes AmazonCloudFormationMigrateStackTask and
- * AmazonCloudFormationWaitStackStatusTask have been merged into one,
- * and over time several refactorings were performed.
- *
- * The original work was published with the following copyright notice:
- *
- * Copyright 2015-2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 package cloud.rio.amazonas
 


### PR DESCRIPTION
In the licence of this class, the attribution to jp.classmethod.aws.gradle.cloudformation was unnecessary and is removed with this commit.