### PR TITLE
Add retry mechanism for retrieveCurrentPipelineStatus method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = "0.0.5-SNAPSHOT"
+version = "0.0.6-SNAPSHOT"
 group = "cloud.rio"
 
 val awsSdkVersion = "1.11.481"
@@ -99,7 +99,7 @@ tasks.named<Upload>("uploadArchives") {
                         }
                     }
 
-                    
+
                     "developers" {
                         "developer" {
                             setProperty("id", "danielgoetz")


### PR DESCRIPTION
The AWS api is eventual consistent, therefore it might happen that
the already started pipeline cannot be found by the getPipelineExecution
method. A time based retry mechanism in the retrieveCurrentPipelineStatus
method is implemented to cope with that issue.