### PR TITLE
Add class EcrAuthorizationHelper.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = "0.0.6-SNAPSHOT"
+version = "0.0.7-SNAPSHOT"
 group = "cloud.rio"
 
 val awsSdkVersion = "1.11.481"
@@ -31,6 +31,7 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-s3:$awsSdkVersion")
     implementation("com.amazonaws:aws-java-sdk-acm:$awsSdkVersion")
     implementation("com.amazonaws:aws-java-sdk-route53:$awsSdkVersion")
+    implementation("com.amazonaws:aws-java-sdk-ecr:$awsSdkVersion")
     testCompile("org.junit.jupiter:junit-jupiter-api:$junit5Version")
     testCompile("org.junit.jupiter:junit-jupiter-params:$junit5Version")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junit5Version")

--- a/src/main/kotlin/cloud/rio/amazonas/EcrAuthorizationHelper.kt
+++ b/src/main/kotlin/cloud/rio/amazonas/EcrAuthorizationHelper.kt
@@ -1,0 +1,34 @@
+package cloud.rio.amazonas
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import org.apache.commons.codec.binary.Base64
+import java.io.UnsupportedEncodingException
+import com.amazonaws.services.ecr.AmazonECR
+import com.amazonaws.services.ecr.AmazonECRClientBuilder
+import com.amazonaws.services.ecr.model.GetAuthorizationTokenRequest
+import java.nio.charset.Charset
+
+
+class DockerCredentials (
+    internal var username: String,
+    internal var password: String
+)
+
+class EcrAuthorizationHelper(private val amazonECR: AmazonECR) {
+
+    val dockerCredentials: DockerCredentials
+        get() {
+            val getAuthorizationTokenResult = amazonECR.getAuthorizationToken(GetAuthorizationTokenRequest())
+            val decodedToken = Base64.decodeBase64(getAuthorizationTokenResult.authorizationData.first().authorizationToken)
+            val credentials = String(decodedToken, Charset.forName("UTF-8"))
+                    .split(":".toRegex())
+                    .dropLastWhile { it.isEmpty() }
+                    .toTypedArray()
+
+            return DockerCredentials(credentials[0], credentials[1])
+        }
+
+    constructor(credentialsProvider: AWSCredentialsProvider, region: String) :
+            this(AmazonECRClientBuilder.standard().withRegion(region).withCredentials(credentialsProvider).build())
+
+}

--- a/src/test/kotlin/cloud/rio/amazonas/EcrAuthorizationHelperTest.kt
+++ b/src/test/kotlin/cloud/rio/amazonas/EcrAuthorizationHelperTest.kt
@@ -1,0 +1,36 @@
+package cloud.rio.amazonas
+
+import com.amazonaws.services.ecr.AmazonECR
+import com.amazonaws.services.ecr.model.AuthorizationData
+import com.amazonaws.services.ecr.model.GetAuthorizationTokenResult
+import io.mockk.every
+import io.mockk.mockkClass
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("EcrAuthorizationHelper.dockerCredentials")
+internal class EcrAuthorizationHelperTest {
+
+    private val amazonECR = mockkClass(AmazonECR::class)
+
+    @Test
+    fun `should return Docker credentials`() {
+        val token = "dXNlcjpwYXNzd29yZA==" // base64 encoded string "user:password"
+        val expectedDockerCredentials = DockerCredentials("user", "password")
+        val getAuthorizationTokenResult = GetAuthorizationTokenResult().withAuthorizationData(AuthorizationData().withAuthorizationToken(token))
+        every {
+            amazonECR.getAuthorizationToken(any())
+        } returns getAuthorizationTokenResult
+
+        val authorizationHelper = EcrAuthorizationHelper(amazonECR)
+        val actualDockerCredentials = authorizationHelper.dockerCredentials
+
+        verify { amazonECR.getAuthorizationToken(any()) }
+        assertEquals(expectedDockerCredentials.password, actualDockerCredentials.password)
+        assertEquals(expectedDockerCredentials.username, actualDockerCredentials.username)
+    }
+}


### PR DESCRIPTION
Resolves #2

This commit adds an helper class to retreive Docker credentials for ECR repositories. It comes with a unit test and the version is updated to 0.0.7-SNAPSHOT.