### PR TITLE
Fix loading of CloudFormation template file.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = "0.0.8-SNAPSHOT"
+version = "0.0.9-SNAPSHOT"
 group = "cloud.rio"
 
 val awsSdkVersion = "1.11.481"

--- a/src/main/kotlin/cloud/rio/amazonas/AmazonCloudformationClient.kt
+++ b/src/main/kotlin/cloud/rio/amazonas/AmazonCloudformationClient.kt
@@ -206,7 +206,7 @@ class AmazonCloudformationClient(private val amazonCloudFormation: AmazonCloudFo
 
     private fun loadFile(templatePath: String): String {
         try {
-            return FileUtils.readFileToString(File(System.getProperty("user.dir") + "/$templatePath"))
+            return FileUtils.readFileToString(File(templatePath))
         } catch (e: IOException) {
             throw RuntimeException("Could not read TemplateFile.", e)
         }


### PR DESCRIPTION
This commit fixes a problem in the AmazonCloudformationClient class that occurs in some gradle environments. The variable "templatePath" can now be either absolute or relative.
The version is incremented to 0.0.9-SNAPSHOT.