### PR TITLE
Add class SsmParameterCopier.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = "0.0.9-SNAPSHOT"
+version = "0.0.10-SNAPSHOT"
 group = "cloud.rio"
 
 val awsSdkVersion = "1.11.481"
@@ -32,6 +32,7 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-acm:$awsSdkVersion")
     implementation("com.amazonaws:aws-java-sdk-route53:$awsSdkVersion")
     implementation("com.amazonaws:aws-java-sdk-ecr:$awsSdkVersion")
+    implementation("com.amazonaws:aws-java-sdk-ssm:$awsSdkVersion")
     testCompile("org.junit.jupiter:junit-jupiter-api:$junit5Version")
     testCompile("org.junit.jupiter:junit-jupiter-params:$junit5Version")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junit5Version")

--- a/src/main/kotlin/cloud/rio/amazonas/CodePipelineRunner.kt
+++ b/src/main/kotlin/cloud/rio/amazonas/CodePipelineRunner.kt
@@ -110,7 +110,7 @@ class CodePipelineRunner(
         )
         private const val waitForFinalPipelineStatusTimeout = 10 * 60//sec
         private const val retrieveCurrentPipelineStatusTimeout = 1 * 60//sec
-        private val LOGGER = LogManager.getLogger(AmazonCloudformationClient::class.java)
+        private val LOGGER = LogManager.getLogger(CodePipelineRunner::class.java)
     }
 }
 

--- a/src/main/kotlin/cloud/rio/amazonas/SsmParameterCopier.kt
+++ b/src/main/kotlin/cloud/rio/amazonas/SsmParameterCopier.kt
@@ -1,0 +1,93 @@
+package cloud.rio.amazonas
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.services.kms.AWSKMS
+import com.amazonaws.services.kms.AWSKMSClientBuilder
+import com.amazonaws.services.kms.model.ListAliasesRequest
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
+import com.amazonaws.services.simplesystemsmanagement.model.*
+import org.apache.logging.log4j.LogManager
+
+class SsmParameterCopier(
+    private val sourceSsm: AWSSimpleSystemsManagement,
+    private val targetSsm: AWSSimpleSystemsManagement,
+    private val kmsClient: AWSKMS
+) {
+    constructor(sourceCredentialsProvider: AWSCredentialsProvider, targetCredentialsProvider: AWSCredentialsProvider, region: String) :
+            this(
+                    AWSSimpleSystemsManagementClientBuilder.standard()
+                            .withRegion(region).withCredentials(sourceCredentialsProvider).build(),
+                    AWSSimpleSystemsManagementClientBuilder.standard()
+                            .withRegion(region).withCredentials(targetCredentialsProvider).build(),
+                    AWSKMSClientBuilder.standard()
+                            .withRegion(region).withCredentials(targetCredentialsProvider).build()
+            )
+
+    fun copyParameter(sourceName: String, targetName: String, encryptionKeyName: String = "aws/kms") {
+        val getParameterResult = sourceSsm.getParameter(
+                GetParameterRequest()
+                        .withName(sourceName)
+                        .withWithDecryption(WITH_DECRYPTION)
+        )
+        val parameter = getParameterResult.parameter
+        LOGGER.info("Successfully read parameter \"{}\".", sourceName)
+
+        val request = if(encryptionKeyName != "aws/kms") {
+            PutParameterRequest()
+                    .withName(targetName)
+                    .withValue(parameter.value)
+                    .withType(parameter.type)
+                    .withKeyId(getKeyId(encryptionKeyName))
+                    .withOverwrite(OVERWRITE)
+        } else {
+            PutParameterRequest()
+                    .withName(targetName)
+                    .withValue(parameter.value)
+                    .withType(parameter.type)
+                    .withOverwrite(OVERWRITE)
+        }
+
+        val putParameterResult = targetSsm.putParameter(request)
+        LOGGER.info("Successfully set version {} of parameter \"{}\".", putParameterResult.getVersion(), targetName)
+    }
+
+    private fun getKeyId(keyName: String?): String? {
+        if (keyName == null) {
+            return null
+        }
+
+        var done = false
+        val request = ListAliasesRequest()
+        val alias = "alias/$keyName"
+
+        while (!done) {
+            val response = kmsClient.listAliases(request)
+
+            for (entry in response.aliases) {
+                if (entry.aliasName == alias) {
+                    val keyId = entry.targetKeyId
+                    LOGGER.info("Found matching key for alias \"{}\" with id \"{}\".", alias, keyId)
+                    return keyId
+                }
+            }
+
+            if (!response.isTruncated) {
+                done = true
+            } else {
+                LOGGER.info("No key with matching alias found yet, make another request...")
+                request.marker = response.nextMarker
+            }
+        }
+        throw NoEncryptionKeyFoundException(String.format("No matching key found for alias \"%s\"", alias))
+    }
+
+    companion object {
+        private val LOGGER = LogManager.getLogger(SsmParameterCopier::class.java)
+        private const val OVERWRITE = true
+        private const val WITH_DECRYPTION = true
+    }
+
+}
+
+class NoEncryptionKeyFoundException internal constructor(message: String) : RuntimeException(message)

--- a/src/test/kotlin/cloud/rio/amazonas/SsmParameterCopierTest.kt
+++ b/src/test/kotlin/cloud/rio/amazonas/SsmParameterCopierTest.kt
@@ -1,0 +1,88 @@
+package cloud.rio.amazonas
+
+import com.amazonaws.services.kms.AWSKMS
+import com.amazonaws.services.kms.model.AliasListEntry
+import com.amazonaws.services.kms.model.ListAliasesResult
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter
+import com.amazonaws.services.simplesystemsmanagement.model.PutParameterRequest
+import com.amazonaws.services.simplesystemsmanagement.model.PutParameterResult
+import io.mockk.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("SsmParameterCopier.copy() should")
+internal class SsmParameterCopierTest {
+
+    private val sourceSsm = mockkClass(AWSSimpleSystemsManagement::class)
+    private val targetSsm = mockkClass(AWSSimpleSystemsManagement::class)
+    private val kmsClient = mockkClass(AWSKMS::class)
+
+    @AfterEach
+    fun resetMocks() {
+        clearAllMocks()
+    }
+
+    @Test
+    @DisplayName("copy a parameter from the source to the target parameter store")
+    fun copyParameter() {
+        val sourceKey = "source-parameter"
+        val sourceValue = "value"
+        val targetKey = "target-parameter"
+        every {
+            sourceSsm.getParameter(match { it.name == sourceKey })
+        } returns
+                GetParameterResult().withParameter(Parameter().withName(sourceKey).withValue(sourceValue))
+        every {
+            targetSsm.putParameter(match { it.name == targetKey })
+        } returns
+                PutParameterResult().withVersion(1L)
+
+        val copier = SsmParameterCopier(sourceSsm, targetSsm, kmsClient)
+        copier.copyParameter(sourceKey, targetKey)
+
+        val slot = slot<PutParameterRequest>()
+        verify { targetSsm.putParameter(capture(slot)) }
+        val actualRequest = slot.captured
+        assertEquals(targetKey, actualRequest.name)
+        assertEquals(sourceValue, actualRequest.value)
+    }
+
+    @Test
+    @DisplayName("if a key alias is specified, encrypt the target parameter with the corresponding key")
+    fun copyParameterWithEncryption() {
+        val sourceKey = "source-parameter"
+        val sourceValue = "value"
+        val targetKey = "target-parameter"
+        val keyName = "the-key"
+        val targetKeyId = "right-key"
+        every {
+            sourceSsm.getParameter(match { it.name == sourceKey && it.isWithDecryption!! })
+        } returns
+                GetParameterResult().withParameter(Parameter().withName(sourceKey).withValue(sourceValue))
+        every {
+            targetSsm.putParameter(match { it.name == targetKey })
+        } returns
+                PutParameterResult().withVersion(1L)
+        every {
+            kmsClient.listAliases(any())
+        } returns
+                ListAliasesResult()
+                        .withAliases(
+                                AliasListEntry().withAliasName("alias/another-key").withTargetKeyId("wrong-key"),
+                                AliasListEntry().withAliasName("alias/the-key").withTargetKeyId(targetKeyId)
+                        )
+
+        val copier = SsmParameterCopier(sourceSsm, targetSsm, kmsClient)
+        copier.copyParameter(sourceKey, targetKey, encryptionKeyName = keyName)
+
+        val slot = slot<PutParameterRequest>()
+        verify { targetSsm.putParameter(capture(slot)) }
+        val actualRequest = slot.captured
+        assertEquals(targetKey, actualRequest.name)
+        assertEquals(sourceValue, actualRequest.value)
+        assertEquals(targetKeyId, actualRequest.keyId)
+    }
+}


### PR DESCRIPTION
The new class is useful to securely copy parameters in the SSM parameter store between different AWS accounts and comes with unit tests.
This commit also fixes a naming problem in the logger of the CodePipelineRunner.
The version is incremented to 0.0.10-SNAPSHOT.